### PR TITLE
Added dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# This Dockerfile is used for development purposes for the alocateam.
+
+FROM openjdk:15-slim
+
+RUN apt update && \
+    apt install python3-pip -y
+
+# parquet-tools csv data/experiments.parquet > ./data/experiments.csv
+RUN pip3 install parquet-tools
+
+CMD bash

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker build -t opendc-dev .
 
 ```bash
 # Start container
-docker run -dit -v /path/to/local/opendc:/home/opendc/ --name opendc-dev 4f24e31f722d bash
+docker run -dit -v /path/to/local/opendc:/home/opendc/ --name opendc-dev opendc-dev:latest bash
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,12 +12,31 @@ The `old-master` is a copy of the original `master` branch and is kept as a refe
 
 There is shell script in the simulator folder that allows you to easily run experiments. To run script:
 
-#### Navigate to simulator folder:
+### (Optional) Create a dev container
+
+```bash
+# Build container
+docker build -t opendc-dev .
+```
+
+```bash
+# Start container
+docker run -dit -v /path/to/local/opendc:/home/opendc/ --name opendc-dev 4f24e31f722d bash
+```
+
+```bash
+# Get into container's shell
+docker exec -it opendc-dev bash
+```
+
+#### Navigate to simulator folder
+
 ```shell script
 cd simulator
 ```
 
-#### Run script:
+#### Run script
+
 ```shell script
 ./run-experiments.sh ./ds_exp/mock/env ./ds_exp/mock/traces test
 ```
@@ -26,12 +45,12 @@ The arguments have the following meaning:
 - `./ds_exp/mock/traces`: Path to experiment traces
 - `test`: Portfolio
 
- #### View results
- 
- After running the script a folder called `data` should be created in the current directory. The folder contains experiment results
- in the parquet format. To view parquet files you can install *parquet_tools*: `brew install parquet-tools`
- 
- To view experiment results:
- ```shell script
+#### View results
+
+After running the script a folder called `data` should be created in the current directory. The folder contains experiment results
+in the parquet format. To view parquet files you can install *parquet_tools*: `brew install parquet-tools`
+
+To view experiment results:
+```shell script
 parquet-tools cat --json data/experiments.parquet > ./data/experiments.json
 ```  

--- a/README.md
+++ b/README.md
@@ -48,9 +48,21 @@ The arguments have the following meaning:
 #### View results
 
 After running the script a folder called `data` should be created in the current directory. The folder contains experiment results
-in the parquet format. To view parquet files you can install *parquet_tools*: `brew install parquet-tools`
+in the parquet format. 
+
+To view parquet files you can install *parquet_tools*
+
+##### Dev container
+
+To view experiment results:
+```bash
+parquet-tools csv data/experiments.parquet > ./data/experiments.csv
+```
+
+##### mac OS
+`brew install parquet-tools`
 
 To view experiment results:
 ```shell script
 parquet-tools cat --json data/experiments.parquet > ./data/experiments.json
-```  
+```

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,18 +2,18 @@ version: "3.8"
 
 # Docker Compose overrides for development environments
 services:
-  frontend:
-    build:
-      args:
-        OPENDC_API_BASE_URL: http://localhost:8081
-    ports:
-      - "8080:80"
+  # frontend:
+  #   build:
+  #     args:
+  #       OPENDC_API_BASE_URL: http://localhost:8081
+  #   ports:
+  #     - "8080:80"
 
-  api:
-    ports:
-      - "8081:8081"
-    environment:
-      SENTRY_ENVIRONMENT: "development"
+  # api:
+  #   ports:
+  #     - "8081:8081"
+  #   environment:
+  #     SENTRY_ENVIRONMENT: "development"
 
   simulator:
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,36 +1,36 @@
 version: "3.8"
 services:
-  frontend:
-    build:
-      context: ./frontend
-      args:
-        OPENDC_OAUTH_CLIENT_ID: ${OPENDC_OAUTH_CLIENT_ID}
-        OPENDC_FRONTEND_SENTRY_DSN: ${OPENDC_FRONTEND_SENTRY_DSN}
-    image: frontend
-    restart: on-failure
-    networks:
-      - backend
+  # frontend:
+  #   build:
+  #     context: ./frontend
+  #     args:
+  #       OPENDC_OAUTH_CLIENT_ID: ${OPENDC_OAUTH_CLIENT_ID}
+  #       OPENDC_FRONTEND_SENTRY_DSN: ${OPENDC_FRONTEND_SENTRY_DSN}
+  #   image: frontend
+  #   restart: on-failure
+  #   networks:
+  #     - backend
 
-  api:
-    build: ./api
-    image: api
-    restart: on-failure
-    networks:
-      - backend
-    depends_on:
-      - mongo
-    environment:
-      - MONGO_INITDB_ROOT_USERNAME
-      - MONGO_INITDB_ROOT_PASSWORD
-      - MONGO_INITDB_DATABASE
-      - OPENDC_DB
-      - OPENDC_DB_USERNAME
-      - OPENDC_DB_PASSWORD
-      - OPENDC_DB_HOST=mongo
-      - OPENDC_FLASK_SECRET
-      - OPENDC_OAUTH_CLIENT_ID
-      - SENTRY_DSN=${OPENDC_API_SENTRY_DSN}
-      - SENTRY_ENVIRONMENT
+  # api:
+  #   build: ./api
+  #   image: api
+  #   restart: on-failure
+  #   networks:
+  #     - backend
+  #   depends_on:
+  #     - mongo
+  #   environment:
+  #     - MONGO_INITDB_ROOT_USERNAME
+  #     - MONGO_INITDB_ROOT_PASSWORD
+  #     - MONGO_INITDB_DATABASE
+  #     - OPENDC_DB
+  #     - OPENDC_DB_USERNAME
+  #     - OPENDC_DB_PASSWORD
+  #     - OPENDC_DB_HOST=mongo
+  #     - OPENDC_FLASK_SECRET
+  #     - OPENDC_OAUTH_CLIENT_ID
+  #     - SENTRY_DSN=${OPENDC_API_SENTRY_DSN}
+  #     - SENTRY_ENVIRONMENT
 
   simulator:
     build: ./simulator


### PR DESCRIPTION
Created a dev container with JDK and a parquet-tool.

Trello card: https://trello.com/c/ET9VRouR/51-make-development-dockerfile-where-we-can-mount-the-codebase-in

Also commented out the irrelevant `docker-compose` parts in case we want to run it through that, might not be needed tho, let me know and I can change.