### PR TITLE
Fix negative idle time bug

### DIFF
--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/idle_time.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/idle_time.py
@@ -25,14 +25,12 @@ class IdleTimeMetric(Metric):
         unused_servers = topology_size - len(server_stats)
         unused_server_time = job_df.finish_time.max() * unused_servers
         if unused_servers > 0:
-            print("Warning: unused servers are not considered for idle time")
+            print(f"Warning: topology not fully utilised ({unused_servers} machine(s) that are 100% idle)")
             print("topology: {}, allocation policy: {}, workload: {}".format(
                 run.topology,
                 run.allocation_policy,
                 run.workload_name
             ))
-            print("Unused servers:", unused_servers)
             print()
         idle_time_per_server = (server_stats.idle_time.sum() + unused_server_time) / topology_size
-        print(idle_time_per_server / job_df.finish_time.max() * 100)
         yield idle_time_per_server / job_df.finish_time.max() * 100

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/idle_time.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/idle_time.py
@@ -6,10 +6,33 @@ class IdleTimeMetric(Metric):
     def __init__(self, plot, runs):
         super().__init__(plot, runs)
         self.name = "idle_time"
-        self.x_axis_label = "Idle time (in seconds)"
+        self.x_axis_label = "Average idle percentage (per machine)"
 
     def get_data(self, run):
-        run_duration = pd.read_parquet(metric_path("run-duration", run)).run_duration[0]
-        df = pd.read_parquet(metric_path("task-lifecycle", run))
-        df['duration'] = df.finish_time - df.start_time
-        yield ((run_duration - df.duration.sum()) / (run_duration // 1000)) * 100
+        job_df = pd.read_parquet(metric_path("job-lifecycle", run))
+        task_df = pd.read_parquet(metric_path("task-lifecycle", run))
+        task_df["duration"] = task_df.finish_time - task_df.start_time
+
+        server_stats = task_df.groupby("server_id").aggregate({"duration": ["sum"]})
+        server_stats["idle_time"] = job_df.finish_time.max() - server_stats.duration
+
+        sizes = {
+            "small": 32,
+            "medium": 256,
+            "large": 10000
+        }
+        topology_size = sizes[run.topology]
+        unused_servers = topology_size - len(server_stats)
+        unused_server_time = job_df.finish_time.max() * unused_servers
+        if unused_servers > 0:
+            print("Warning: unused servers are not considered for idle time")
+            print("topology: {}, allocation policy: {}, workload: {}".format(
+                run.topology,
+                run.allocation_policy,
+                run.workload_name
+            ))
+            print("Unused servers:", unused_servers)
+            print()
+        idle_time_per_server = (server_stats.idle_time.sum() + unused_server_time) / topology_size
+        print(idle_time_per_server / job_df.finish_time.max() * 100)
+        yield idle_time_per_server / job_df.finish_time.max() * 100

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/plot.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/plot.py
@@ -8,9 +8,10 @@ from typing import List, Dict, Type
 import pandas as pd
 import seaborn as sns
 
-import metrics
 from metrics import Metric, Plot
-
+from metrics.plot import MetricWorkloadBarPlot as bar_plot
+from metrics.plot import MetricWorkloadViolinPlot as violin_plot
+import metrics
 
 def iter_runs(experiments):
     for portfolio_id in experiments['portfolio_id'].unique():
@@ -25,10 +26,9 @@ class Plotter:
     OUTPUT_PATH = f"{Path(__file__).parent.resolve()}/results/{datetime.now():%Y-%m-%d-%H-%M-%S}"
 
     def __init__(self,
-                 metric_classes: List[Type[Metric]],
                  plot_classes: Dict[Type[Metric], List[Type[Plot]]],
                  path: Path):
-        self.metric_classes = metric_classes
+        self.metric_classes = list(plot_classes.keys())
         self.plot_classes = plot_classes
         self.path = path
 
@@ -69,29 +69,20 @@ def main():
     )
     args = parser.parse_args()
 
-    plot_types = [
-        metrics.plot.MetricWorkloadBarPlot,
-        metrics.plot.MetricWorkloadViolinPlot
-    ]
-
-    all_metrics = [
-        metrics.JobTurnaroundTimeMetric,
-        metrics.TaskThroughputMetric,
-        metrics.PowerConsumptionMetric,
-        metrics.IdleTimeMetric,
-        metrics.JobWaitingTimeMetric,
-        metrics.JobMakespanMetric,
-    ]
-
     all_plots = {
-        m: plot_types for m in all_metrics
+        metrics.JobTurnaroundTimeMetric: [bar_plot, violin_plot],
+        metrics.TaskThroughputMetric: [bar_plot, violin_plot],
+        metrics.PowerConsumptionMetric: [bar_plot, violin_plot],
+        metrics.IdleTimeMetric: [bar_plot],
+        metrics.JobWaitingTimeMetric: [bar_plot, violin_plot],
+        metrics.JobMakespanMetric: [bar_plot, violin_plot],
     }
 
     sns.set(
         style="darkgrid",
         font_scale=1.6
     )
-    plotter = Plotter(all_metrics, all_plots, args.path)
+    plotter = Plotter(all_plots, args.path)
     plotter.plot_all()
 
 


### PR DESCRIPTION
The idle time is calculated in the following way now:
The individual task duration is computed by taking the difference between the finish time of a task and its start time.
The busy time is  computed by machine by grouping the the tasks by server_id aggregating them by their duration (sum).
Finally, the difference between the busy time and the greatest job finish time (i.e. the run duration) is the idle time per machine.

In addition, I noticed that for some topologies, not all machines were used (see output generated below). To overcome this issue, I included these fully idle machines in the aggregate calculation.

```
Warning: topology not fully utilised (31 machine(s) that are 100% idle)
topology: small, allocation policy: heft, workload: shell

Warning: topology not fully utilised (255 machine(s) that are 100% idle)
topology: medium, allocation policy: heft, workload: shell

Warning: topology not fully utilised (9999 machine(s) that are 100% idle)
topology: large, allocation policy: heft, workload: shell

Warning: topology not fully utilised (6597 machine(s) that are 100% idle)
topology: large, allocation policy: elop, workload: shell

Warning: topology not fully utilised (8998 machine(s) that are 100% idle)
topology: large, allocation policy: heft, workload: askalon_ee

Warning: topology not fully utilised (9606 machine(s) that are 100% idle)
topology: large, allocation policy: heft, workload: spec_trace-2

Warning: topology not fully utilised (4112 machine(s) that are 100% idle)
topology: large, allocation policy: elop, workload: spec_trace-2
```