### PR TITLE
Added script to show reproducibility.

### DIFF
--- a/simulator/opendc-experiments/opendc-experiments-allocateam/README.md
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/README.md
@@ -77,3 +77,20 @@ parquet-tools cat --json data/experiments.parquet > ./data/experiments.json
 # Inside opendc/simulator/opendc-experiments/opendc-experiments-allocateam
 ../../gradlew clean test
 ```
+
+## Verify reproducibility
+
+> [verify_reproducibility.py] aims to verify the reproducibility of the Allocateam experiment,
+by first running the experiment three times in setting 3 (medium topology, spec_trace 2, all metrics).
+We then assert that the metrics produced by the three runs are equivalent.
+
+To run the `verify_reproducibility.py` script:
+
+```bash
+# Run the experiment 
+# (setting 3, with 3 allegedly identical runs that will be verified on their equality)
+./tools/run.sh verifyReproducibility
+
+# Run the verify reproducibility script
+python3 ./tools/plot/verify_reproducibility.py data/
+```

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/src/main/kotlin/org/opendc/experiments/allocateam/Main.kt
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/src/main/kotlin/org/opendc/experiments/allocateam/Main.kt
@@ -12,6 +12,7 @@ import mu.KotlinLogging
 import org.opendc.experiments.allocateam.experiment.AllocateamPortfolio
 import org.opendc.experiments.allocateam.experiment.Experiment
 import org.opendc.experiments.allocateam.experiment.Portfolio
+import org.opendc.experiments.allocateam.experiment.VerifyReproducibilityPortfolio
 import org.opendc.experiments.sc20.reporter.ConsoleExperimentReporter
 import org.opendc.experiments.sc20.runner.ExperimentDescriptor
 import org.opendc.experiments.sc20.runner.execution.ThreadPoolExperimentScheduler
@@ -40,6 +41,8 @@ public class ExperimentCli : CliktCommand(name = "allocateam") {
     private val portfolios by option("--portfolio", help = "portfolio of scenarios to explore")
         .choice(
             "smokeTest" to { experiment: Experiment, i: Int -> AllocateamPortfolio(experiment, i) }
+                as (Experiment, Int) -> Portfolio,
+            "verifyReproducibility" to { experiment: Experiment, i: Int -> VerifyReproducibilityPortfolio(experiment, i) }
                 as (Experiment, Int) -> Portfolio,
             ignoreCase = true
         )

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/src/main/kotlin/org/opendc/experiments/allocateam/experiment/Portfolios.kt
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/src/main/kotlin/org/opendc/experiments/allocateam/experiment/Portfolios.kt
@@ -31,3 +31,29 @@ public class AllocateamPortfolio(parent: Experiment, id: Int) : Portfolio(parent
 
     override val repetitions: Int = 1
 }
+
+/**
+ * This portfolio only consists of setting 3, and is used to verify the reproducibility of the Allocateam experiment,
+ * by running setting 3 three times. The output is then compared in a separate Python module in
+ * tools/plot/verify_reproducibility.py.
+ */
+public class VerifyReproducibilityPortfolio(parent: Experiment, id: Int) : Portfolio(parent, id, "VerifyReproducibilityPortfolio") {
+    override val topologies: List<Topology> = listOf(
+        Topology("medium"),
+    )
+
+    override val workloads: List<Workload> = listOf(
+        Workload("spec_trace-2", 1.0),
+    )
+
+    override val resourceAllocationPolicies: List<String> = listOf(
+        "min-min",
+        "max-min",
+        "round-robin",
+        "lottery",
+        "heft",
+        "elop"
+    )
+
+    override val repetitions: Int = 3
+}

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/idle_time.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/idle_time.py
@@ -3,13 +3,13 @@ import pandas as pd
 
 
 class IdleTimeMetric(Metric):
-    def __init__(self, plot, runs):
-        super().__init__(plot, runs)
+    def __init__(self, plot, scenarios):
+        super().__init__(plot, scenarios)
         self.name = "idle_time"
         self.x_axis_label = "Idle time (in seconds)"
 
-    def get_data(self, run):
-        run_duration = pd.read_parquet(metric_path("run-duration", run)).run_duration[0]
-        df = pd.read_parquet(metric_path("task-lifecycle", run))
+    def get_data(self, scenario):
+        run_duration = pd.read_parquet(metric_path("run-duration", scenario)).run_duration[0]
+        df = pd.read_parquet(metric_path("task-lifecycle", scenario))
         df['duration'] = df.finish_time - df.start_time
         yield ((run_duration - df.duration.sum()) / (run_duration // 1000)) * 100

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/job_makespan.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/job_makespan.py
@@ -4,14 +4,14 @@ import math
 
 
 class JobMakespanMetric(Metric):
-    def __init__(self, plot, runs):
-        super().__init__(plot, runs)
+    def __init__(self, plot, scenarios):
+        super().__init__(plot, scenarios)
         self.name = "job_makespan"
         self.x_axis_label = "Job makespan (seconds)"
 
-    def get_data(self, run):
-        job_df = pd.read_parquet(metric_path("job-lifecycle", run))
-        task_df = pd.read_parquet(metric_path("task-lifecycle", run))
+    def get_data(self, scenario):
+        job_df = pd.read_parquet(metric_path("job-lifecycle", scenario))
+        task_df = pd.read_parquet(metric_path("task-lifecycle", scenario))
 
         for job_id in job_df.job_id.unique():
             tasks = task_df[task_df.job_id == job_id]

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/job_turnaround_time.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/job_turnaround_time.py
@@ -3,13 +3,13 @@ import pandas as pd
 
 
 class JobTurnaroundTimeMetric(Metric):
-    def __init__(self, plot, runs):
-        super().__init__(plot, runs)
+    def __init__(self, plot, scenarios):
+        super().__init__(plot, scenarios)
         self.name = "job_turnaround"
         self.x_axis_label = "Turnaround time (seconds)"
 
-    def get_data(self, run):
-        job_df = pd.read_parquet(metric_path("job-lifecycle", run))
+    def get_data(self, scenario):
+        job_df = pd.read_parquet(metric_path("job-lifecycle", scenario))
         times = (job_df.finish_time - job_df.start_time) // 1000
         for row in times:
             yield row

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/job_waiting_time.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/job_waiting_time.py
@@ -4,14 +4,14 @@ import math
 
 
 class JobWaitingTimeMetric(Metric):
-    def __init__(self, plot, runs):
-        super().__init__(plot, runs)
+    def __init__(self, plot, scenarios):
+        super().__init__(plot, scenarios)
         self.name = "job_waiting_time"
         self.x_axis_label = "Job waiting time (in seconds)"
 
-    def get_data(self, run):
-        job_df = pd.read_parquet(metric_path("job-lifecycle", run))
-        task_df = pd.read_parquet(metric_path("task-lifecycle", run))
+    def get_data(self, scenario):
+        job_df = pd.read_parquet(metric_path("job-lifecycle", scenario))
+        task_df = pd.read_parquet(metric_path("task-lifecycle", scenario))
 
         for _, job in job_df.iterrows():
             tasks = task_df[task_df.job_id == job.job_id]

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/metric.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/metric.py
@@ -16,21 +16,21 @@ def metric_path(name, run):
 
 
 class Metric(ABC):
-    def __init__(self, plots: List[Type[Plot]], runs):
+    def __init__(self, plots: List[Type[Plot]], scenarios):
         self.name = "metric"
         self.plots = plots
-        self.runs = runs
+        self.scenarios = scenarios
         self.x_axis_label = "no label"
 
     def metric_dataframe(self) -> pd.DataFrame:
         result = []
-        for run in self.runs:
-            for value in self.get_data(run):
+        for scenario in self.scenarios:
+            for value in self.get_data(scenario):
                 result.append({
-                    "portfolio_id": run.portfolio_id,
-                    "topology": run.topology,
-                    "workload": run.workload_name,
-                    "allocation_policy": run.allocation_policy,
+                    "portfolio_id": scenario.portfolio_id,
+                    "topology": scenario.topology,
+                    "workload": scenario.workload_name,
+                    "allocation_policy": scenario.allocation_policy,
                     self.name: value,
                 })
         return pd.DataFrame.from_dict(result)

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/metric.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/metric.py
@@ -8,9 +8,9 @@ from pathlib import Path
 BASE_DATA_PATH = (Path(__file__).parent / "../../../data").resolve()
 
 
-def metric_path(name, run):
+def metric_path(name, scenario):
     partition = "portfolio_id={}/scenario_id={}/run_id={}".format(
-        run.portfolio_id, run.scenario_id, run.run_id
+        scenario.portfolio_id, scenario.scenario_id, scenario.run_id
     )
     return Path(BASE_DATA_PATH) / name / partition / "data.parquet"
 
@@ -41,5 +41,5 @@ class Metric(ABC):
             plot().generate(df, self, plotter, self.x_axis_label)
 
     @abstractmethod
-    def get_data(self, run):
+    def get_data(self, scenario):
         pass

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/power_consumption.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/power_consumption.py
@@ -4,14 +4,14 @@ import numpy as np
 
 
 class PowerConsumptionMetric(Metric):
-    def __init__(self, plot, runs):
-        super().__init__(plot, runs)
+    def __init__(self, plot, scenarios):
+        super().__init__(plot, scenarios)
         self.name = "power_consumption"
         self.x_axis_label = "Power Consumption (watt-hours)"
 
-    def get_data(self, run):
-        run_duration = pd.read_parquet(metric_path("run-duration", run)).run_duration[0]
-        df = pd.read_parquet(metric_path("power-consumption", run))
+    def get_data(self, scenario):
+        run_duration = pd.read_parquet(metric_path("run-duration", scenario)).run_duration[0]
+        df = pd.read_parquet(metric_path("power-consumption", scenario))
         power_consumption = []
         for node in df.server_id.unique():
             timestamps = df[df.server_id == node].sort_values(by='timestamp')

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/task_throughput.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/metrics/task_throughput.py
@@ -3,13 +3,13 @@ import pandas as pd
 
 
 class TaskThroughputMetric(Metric):
-    def __init__(self, plot, runs):
-        super().__init__(plot, runs)
+    def __init__(self, plot, scenarios):
+        super().__init__(plot, scenarios)
         self.name = "task_throughput"
         self.x_axis_label = "Task throughput (tasks per hour)"
 
-    def get_data(self, run):
-        run_duration = pd.read_parquet(metric_path("run-duration", run)).run_duration[0]
-        task_df = pd.read_parquet(metric_path("task-lifecycle", run))
-        print(run.topology, run.workload_name, len(task_df))
+    def get_data(self, scenario):
+        run_duration = pd.read_parquet(metric_path("run-duration", scenario)).run_duration[0]
+        task_df = pd.read_parquet(metric_path("task-lifecycle", scenario))
+        print(scenario.topology, scenario.workload_name, len(task_df))
         yield len(task_df) / (run_duration // 1000 // 60 // 60)

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/verify_reproducibility.py
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/plot/verify_reproducibility.py
@@ -1,0 +1,89 @@
+"""This module aims to verify the reproducibility of the Allocateam experiment, 
+by first running the experiment three times in setting 3 (medium topology, spec_trace 2, all metrics).
+We then assert that the metrics produced by the three runs are equivalent.
+"""
+
+import argparse
+import os.path as path
+import shlex
+import subprocess
+from pathlib import Path
+from typing import List, Type, Dict
+
+import metrics
+import pandas as pd
+from metrics import Metric, Plot
+import plot
+
+
+def collect_metrics(data_path: Path, metric_classes: List[Type[Metric]]) -> Dict[int, List[pd.DataFrame]]:
+    """Collect metrics per run.
+
+    Args:
+        data_path (Path): Path to the metrics.
+        metric_classes (List[Type[Metric]]): List of metrics to collect.
+
+    Returns:
+        Dict[int, List[pd.DataFrame]]: Key is run id. Value is list of metrics per scenario.
+    """
+    experiments = pd.read_parquet(f"{data_path}/experiments.parquet")
+    
+    scenarios_by_run: dict = {}
+    for scenario in plot.iter_runs(experiments):
+        if not scenarios_by_run.get(scenario.run_id):
+            scenarios_by_run[scenario.run_id] = []
+        scenarios_by_run[scenario.run_id].append(scenario)
+
+    metrics_by_run: dict = {}
+    for run, scenarios in scenarios_by_run.items():
+        for metric in metric_classes:
+            df = metric([], scenarios).metric_dataframe()
+            if not metrics_by_run.get(run):
+                metrics_by_run[run] = []
+            metrics_by_run[run].append(df)
+
+    return metrics_by_run
+
+def assert_equality(metrics_per_run: Dict[int, List[pd.DataFrame]]):
+    """Assert that the metrics for each run are the same.
+
+    Args:
+        metrics_per_run (Dict[int, List[pd.DataFrame]]): The metrics per run.
+    """
+    print("Verifying that each run returns equal results.")
+    for run_id_a, run_metrics_a in metrics_per_run.items():
+        for run_id_b, run_metrics_b in metrics_per_run.items():
+            if run_id_a == run_id_b: continue
+            for i in range(len(run_metrics_a)):
+                print(f"Asserting equality for run {run_id_a} and run {run_id_b}")
+                print(f"For the metric: {run_metrics_a[i].columns[-1]}")
+                assert list(run_metrics_a[i]) == list(run_metrics_b[i])
+    print("All runs are equal!")
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify reproducibility for the Allocateam experiment.")
+    parser.add_argument(
+        "path",
+        nargs='?',
+        type=str,
+        help="The path to data dir.",
+        default=metrics.metric.BASE_DATA_PATH,
+    )
+    args = parser.parse_args()
+
+    all_metrics = [
+        metrics.JobTurnaroundTimeMetric,
+        metrics.TaskThroughputMetric,
+        metrics.PowerConsumptionMetric,
+        metrics.IdleTimeMetric,
+        metrics.JobWaitingTimeMetric,
+        metrics.JobMakespanMetric,
+    ]
+
+    metrics_per_run = collect_metrics(args.path, all_metrics)
+    assert_equality(metrics_per_run)
+    
+
+if __name__ == "__main__":
+    """Usage: python3 verify_reproducibility.py <path_to_data_dir>"""
+    main()

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/run.sh
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/run.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# This script runs the Allocateam experiment.
+# Usage: ./tools/run.sh smokeTest
 
 set -euo pipefail
 
@@ -14,12 +16,19 @@ command -v realpath > /dev/null 2>&1 || realpath() {
 
 # Check if data directory exists and ask user what to do as we don't want to remove data
 if [ -d "$DATA_DIR" ]; then
-	read -rp "data directory exists. Remove it (y/n)? " choice
-	case "$choice" in
-		y|Y ) rm -r "$DATA_DIR" && mkdir "$DATA_DIR";;
-		n|N ) echo "Cannot proceed without (re)moving data directory. Aborting..."; exit 1;;
-		* ) echo "Ambiguous answer. Aborting..."; exit 2;;
-	esac
+	while getopts ":y" opt; do # if -y option is given, remove data dir.
+		case $opt in
+			y) echo "Removing data directory.." && rm -r "$DATA_DIR" && mkdir "$DATA_DIR";;
+		esac
+		done
+	if [ $OPTIND -eq 1 ]; then  # if no options given, prompt for data dir removal.
+		read -rp "data directory exists. Remove it (y/n)? " choice
+		case "$choice" in
+			y|Y ) rm -r "$DATA_DIR" && mkdir "$DATA_DIR";;
+			n|N ) echo "Cannot proceed without (re)moving data directory. Aborting..."; exit 1;;
+			* ) echo "Ambiguous answer. Aborting..."; exit 2;;
+		esac
+	fi
 else
 	mkdir "$DATA_DIR"
 fi

--- a/simulator/opendc-experiments/opendc-experiments-allocateam/tools/setup.sh
+++ b/simulator/opendc-experiments/opendc-experiments-allocateam/tools/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-
+# This script downloads the traces.
+# Usage: ./tools/setup.sh
 
 tracesDir="$( cd "$(dirname "$0")/../" > /dev/null 2>&1 || exit ; pwd -P )/src/main/resources/traces"
 


### PR DESCRIPTION
# Output of running the script

```
root@3e3eaf467792:/home/opendc/simulator/opendc-experiments/opendc-experiments-allocateam# python3 tools/plot/verify_reproducibility.py data/
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
medium spec_trace-2 13876
Verifying that each run returns equal results.
Asserting equality for run 0 and run 1
For the metric: job_turnaround
Asserting equality for run 0 and run 1
For the metric: task_throughput
Asserting equality for run 0 and run 1
For the metric: power_consumption
Asserting equality for run 0 and run 1
For the metric: idle_time
Asserting equality for run 0 and run 1
For the metric: job_waiting_time
Asserting equality for run 0 and run 1
For the metric: job_makespan
Asserting equality for run 0 and run 2
For the metric: job_turnaround
Asserting equality for run 0 and run 2
For the metric: task_throughput
Asserting equality for run 0 and run 2
For the metric: power_consumption
Asserting equality for run 0 and run 2
For the metric: idle_time
Asserting equality for run 0 and run 2
For the metric: job_waiting_time
Asserting equality for run 0 and run 2
For the metric: job_makespan
Asserting equality for run 1 and run 0
For the metric: job_turnaround
Asserting equality for run 1 and run 0
For the metric: task_throughput
Asserting equality for run 1 and run 0
For the metric: power_consumption
Asserting equality for run 1 and run 0
For the metric: idle_time
Asserting equality for run 1 and run 0
For the metric: job_waiting_time
Asserting equality for run 1 and run 0
For the metric: job_makespan
Asserting equality for run 1 and run 2
For the metric: job_turnaround
Asserting equality for run 1 and run 2
For the metric: task_throughput
Asserting equality for run 1 and run 2
For the metric: power_consumption
Asserting equality for run 1 and run 2
For the metric: idle_time
Asserting equality for run 1 and run 2
For the metric: job_waiting_time
Asserting equality for run 1 and run 2
For the metric: job_makespan
Asserting equality for run 2 and run 0
For the metric: job_turnaround
Asserting equality for run 2 and run 0
For the metric: task_throughput
Asserting equality for run 2 and run 0
For the metric: power_consumption
Asserting equality for run 2 and run 0
For the metric: idle_time
Asserting equality for run 2 and run 0
For the metric: job_waiting_time
Asserting equality for run 2 and run 0
For the metric: job_makespan
Asserting equality for run 2 and run 1
For the metric: job_turnaround
Asserting equality for run 2 and run 1
For the metric: task_throughput
Asserting equality for run 2 and run 1
For the metric: power_consumption
Asserting equality for run 2 and run 1
For the metric: idle_time
Asserting equality for run 2 and run 1
For the metric: job_waiting_time
Asserting equality for run 2 and run 1
For the metric: job_makespan
All runs are equal!
```